### PR TITLE
Json annotation fix

### DIFF
--- a/active/af1-dequeue-and-identify-phi.py
+++ b/active/af1-dequeue-and-identify-phi.py
@@ -182,7 +182,7 @@ def annotate_clinical_notes(**kwargs):
 
         for blobid, record in to_review_by_assignee.items():
             try:
-                common_functions.save_deid_annotation(blobid, record['hdcpupdatedate'], str(record['annotated_note']))
+                common_functions.save_deid_annotation(blobid, record['hdcpupdatedate'], json.dumps(record['annotated_note']))
 
             except OperationalError as e:
                 message = ("A OperationalError occurred while trying to store deid annotations to source for"
@@ -195,7 +195,7 @@ def annotate_clinical_notes(**kwargs):
     # Notes Without Review
     for blobid, record in skip_review.items():
         try:
-            common_functions.save_unreviewed_annotation(blobid, record['hdcpupdatedate'], str(record['annotated_note']))
+            common_functions.save_unreviewed_annotation(blobid, record['hdcpupdatedate'], json.dumps(record['annotated_note']))
         except OperationalError as e:
             message = ("A OperationalError occurred while trying to store unreviewed deid annotations to source for"
                        " for blobid: {blobid} {error}".format(blobid=blobid, error=e))

--- a/active/operators/resynthesis/resynthesize_notes.py
+++ b/active/operators/resynthesis/resynthesize_notes.py
@@ -51,7 +51,7 @@ def resynthesize_notes_marked_as_deid(upstream_task, **kwargs):
             for record in batch_records:
                 try:
                     # save json to db
-                    common_functions.save_resynthesis_annotation(blobid, hdcpupdatedate, str(record[blobid]))
+                    common_functions.save_resynthesis_annotation(blobid, hdcpupdatedate, json.dumps(record[blobid]))
                     json_obj_to_store = json.dumps({'resynthesized_notes': record[blobid]['text'],
                                                     'patient_pubid': fake_id,
                                                     'service_date': service_dts[blobid].strftime(


### PR DESCRIPTION
previously AF1 and AF3 were writing dictionaries to the sql server annotation store with single quotes (not parsable json). believe I found the fix here